### PR TITLE
feat(shorebird): enable macOS App Store OTA patches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,7 @@ jobs:
           appstore-profile-liveactivity-debug-base64: ${{ secrets.APPSTORE_PROFILE_LIVEACTIVITY_DEBUG_BASE64 }}
 
       - name: 🐦 Setup Shorebird
-        #if: inputs.build_mac || inputs.build_android || inputs.build_ios
-        if: inputs.build_android || inputs.build_ios
+        if: inputs.build_mac || inputs.build_android || inputs.build_ios
         uses: shorebirdtech/setup-shorebird@v1
         with:
           cache: true
@@ -95,16 +94,21 @@ jobs:
           platform: android
           args: "--obfuscate --split-debug-info=symbols -- --dart-define=REVENUECAT_API_KEY_ANDROID=${{ secrets.REVENUECAT_API_KEY_ANDROID }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}"
 
+      # Ship the macOS store binary through Shorebird so it carries the updater and a
+      # release record exists to patch against. The Mac App Store patch itself needs a
+      # one-time local `register-baseline` step (Apple re-processes the .pkg) — see
+      # scripts/README-shorebird-macos.md and shorebirdtech/shorebird#3223.
       - name: 🚀 Shorebird Release macOS
-        if: inputs.build_mac && false
+        if: inputs.build_mac
         uses: shorebirdtech/shorebird-release@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           platform: macos
           args: "--obfuscate --split-debug-info=symbols -- --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}"
 
+      # Superseded by the Shorebird release above (a plain flutter build can't be patched).
       - name: Flutter Release macOS
-        if: inputs.build_mac
+        if: false
         run:
           flutter build macos --release --obfuscate --split-debug-info=symbols --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -4,10 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       build_mac:
-        # Selecting this currently only installs the signing certificates: the
-        # macOS patch step itself stays disabled until
-        # https://github.com/OpenBikeControl/bikecontrol/issues/143 is fixed.
-        description: 'Patch for macOS (patch step disabled, see #143)'
+        # macOS patches go through the Mac App Store workaround
+        # (scripts/shorebird_mas_patch.rb). This requires a one-time local
+        # `register-baseline` for the target release BEFORE this runs — see
+        # scripts/README-shorebird-macos.md. Off by default because that local
+        # step can't happen in CI. Set release_version to x.y.z+build.
+        description: 'Patch for macOS (needs local register-baseline first, see scripts/README-shorebird-macos.md)'
         required: false
         default: false
         type: boolean
@@ -111,13 +113,33 @@ jobs:
           keystore-base64: ${{ secrets.KEYSTORE_BASE64 }}
           keystore-properties: ${{ secrets.KEYSTORE_PROPERTIES }}
 
-      - name: 🚀 Shorebird Patch macOS
-        if: false # patch doesn't work: https://github.com/OpenBikeControl/bikecontrol/issues/143
-        uses: shorebirdtech/shorebird-patch@v1
-        with:
-          platform: macos
-          release-version: ${{ inputs.release_version }}
-          args: '--track ${{ inputs.track }} --allow-asset-diffs --allow-native-diffs --split-debug-info=symbols -- --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}'
+      # macOS can't use the stock shorebird-patch action: Apple re-processes the
+      # store .pkg, so patches must be built against the store-delivered .app that a
+      # local `register-baseline` uploaded as macos/app_mas_contents. The script
+      # fails fast with a clear message if that baseline is missing.
+      # See scripts/README-shorebird-macos.md and shorebirdtech/shorebird#3223.
+      - name: Prepare App Store authentication key (macOS patch)
+        if: inputs.build_mac
+        env:
+          API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_FILE_BASE64 }}
+          APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
+        run: |
+          mkdir -p ./private_keys
+          printf %s "$API_KEY_BASE64" | base64 -D > "./private_keys/AuthKey_${APPSTORE_API_KEY}.p8"
+
+      - name: 🚀 Shorebird Patch macOS (Mac App Store baseline)
+        if: inputs.build_mac
+        env:
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+          # 'latest' is the workflow default; the script auto-detects the live
+          # READY_FOR_SALE version when RELEASE_VERSION is empty.
+          RELEASE_VERSION: ${{ inputs.release_version == 'latest' && '' || inputs.release_version }}
+          ASC_APP_ID: ${{ secrets.ASC_MACOS_APP_ID }}
+          ASC_KEY_ID: ${{ secrets.APPSTORE_API_KEY }}
+          ASC_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          ASC_API_KEY_PATH: ./private_keys/AuthKey_${{ secrets.APPSTORE_API_KEY }}.p8
+          SHOREBIRD_PATCH_ARGS: "--track ${{ inputs.track }} --allow-asset-diffs --allow-native-diffs --split-debug-info=symbols -- --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}"
+        run: ruby scripts/shorebird_mas_patch.rb patch
 
       - name: 🚀 Shorebird Patch Android
         if: inputs.build_android
@@ -151,15 +173,14 @@ jobs:
           release-version: ${{ inputs.release_version }}
           args: '--track beta --allow-asset-diffs --allow-native-diffs --split-debug-info=symbols -- --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}'
 
-      # build_mac is deliberately not part of these conditions: the macOS patch
-      # step is disabled (#143), so a macOS-only run produces no symbols/ and
-      # the zip would fail. Add it back when that patch step is re-enabled.
+      # macOS, Android and iOS patches all emit --split-debug-info=symbols, so any
+      # of them produces a symbols/ dir to zip.
       - name: Zip Symbols
-        if: inputs.build_android || inputs.build_ios
+        if: inputs.build_mac || inputs.build_android || inputs.build_ios
         run: zip -P "${{ secrets.ZIP_PASSWORD }}" -r symbols.zip symbols/
 
       - name: Upload Symbols
-        if: inputs.build_android || inputs.build_ios
+        if: inputs.build_mac || inputs.build_android || inputs.build_ios
         uses: actions/upload-artifact@v4
         with:
           overwrite: true

--- a/scripts/README-shorebird-macos.md
+++ b/scripts/README-shorebird-macos.md
@@ -1,0 +1,96 @@
+# Shorebird OTA patches for the macOS App Store build
+
+Shorebird cannot patch a Mac App Store build out of the box: Apple re-processes the
+submitted `.pkg` before it reaches users, so the installed binary no longer matches the
+`macos/app` artifact Shorebird captured at release time. A patch built from that artifact
+downloads but fails to load at runtime.
+
+Upstream tracking issue: [shorebirdtech/shorebird#3223](https://github.com/shorebirdtech/shorebird/issues/3223)
+(still open). Our own history: [OpenBikeControl/bikecontrol#143](https://github.com/OpenBikeControl/bikecontrol/issues/143).
+
+`scripts/shorebird_mas_patch.rb` (vendored from
+[this gist](https://gist.github.com/lukemmtt/d52a729010f30c74d004ecd169805dca)) works around
+this by registering the **store-delivered** `.app` as a second release artifact
+(`macos/app_mas_contents`) and pointing `shorebird patch` at it.
+
+## Prerequisites
+
+1. **The macOS build ships through Shorebird.** `.github/workflows/build.yml` runs
+   `shorebird release macos` (not a plain `flutter build macos`) so a Shorebird release
+   record exists for `x.y.z+build` and the store binary contains the updater. Without this
+   there is nothing to patch.
+2. **That build is live** on the Mac App Store (`READY_FOR_SALE`) for the same version.
+3. A Mac signed into the App Store with an Apple ID that can download BikeControl.
+4. App Store Connect API key credentials (the same key CI uses for uploads).
+5. Shorebird auth: either `shorebird login` locally, or `SHOREBIRD_TOKEN` from
+   `shorebird login --ci`.
+6. `mas` CLI (`brew install mas`) if you want the script to download/update the live app for
+   you. Recent `mas` needs `sudo` for install/update.
+
+> **`register-baseline` cannot run in CI.** It needs a Mac logged into the App Store with the
+> live app downloaded, so it is a local step Jonas runs once per macOS release. Only `patch`
+> is CI-friendly (see `.github/workflows/patch.yml`, `build_mac` input, off by default).
+
+## Environment
+
+Run the script from the repo root (next to `pubspec.yaml` / `shorebird.yaml`). Set:
+
+```bash
+export APP_NAME="BikeControl"                 # default; /Applications/BikeControl.app
+export APP_BUNDLE_ID="de.jonasbark.swiftPlay" # default
+export ASC_APP_ID="<numeric Mac app id>"      # App Store Connect app id for the macOS app
+export ASC_KEY_ID="<APPSTORE_API_KEY>"        # same key id CI uses
+export ASC_ISSUER_ID="<APPSTORE_API_ISSUER_ID>"
+export ASC_API_KEY_PATH="$HOME/.private_keys/AuthKey_${ASC_KEY_ID}.p8"
+# Local Shorebird auth via `shorebird login` is enough; otherwise:
+# export SHOREBIRD_TOKEN="<shorebird login --ci token>"
+```
+
+Optional:
+
+```bash
+export MACOS_APP_PATH="/Applications/BikeControl.app"   # default
+export MAS_ARTIFACT_ARCH="app_mas_contents"             # bump to _v2 if a stale one exists
+export MAS_UPDATE_COMMAND="sudo mas update --force --verbose $ASC_APP_ID"
+export SHOREBIRD_PATCH_ARGS="--allow-asset-diffs --allow-native-diffs --split-debug-info=symbols"
+```
+
+Treat `SHOREBIRD_TOKEN` and the `.p8` key as secrets. Do not commit them.
+
+## Usage
+
+```bash
+# Once per live Mac App Store release, after it is READY_FOR_SALE (local, needs App Store login):
+ruby scripts/shorebird_mas_patch.rb register-baseline
+
+# Read-only check that the MAS baseline artifact exists for the target release:
+ruby scripts/shorebird_mas_patch.rb status
+
+# Whenever you want to ship a macOS OTA patch for that release:
+ruby scripts/shorebird_mas_patch.rb patch
+```
+
+`RELEASE_VERSION=x.y.z+build` targets a specific release; if omitted the script uses the
+latest `READY_FOR_SALE` Mac App Store version. Set `DRY_RUN=true` to validate without
+uploading (`register-baseline`) or without shipping (`patch`).
+
+## How the patch step works
+
+`shorebird patch` hardcodes the macOS release artifact arch as `app`. During `patch` the
+script temporarily edits the local CLI source
+(`~/.shorebird/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart`) so
+`primaryReleaseArtifactArch` honours `SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH`, runs the patch
+against `macos/app_mas_contents`, then restores the file and clears the CLI cache stamp.
+
+Because it edits Shorebird CLI internals, **pin the Shorebird version** you use for macOS
+patches — a CLI upgrade can change that file's shape and the script will refuse to patch with
+a clear error rather than corrupt it.
+
+## Operational notes
+
+- If `register-baseline` finds an existing artifact with a different hash, register under a
+  new arch (`MAS_ARTIFACT_ARCH=app_mas_contents_v2`) and pass the same value to `patch`.
+- If the inner Mach-O hashes (`App.framework/App` or `Contents/MacOS/<exe>`) change between
+  captures of the *same* version/build, stop and investigate — the binary baseline itself
+  moved, not just the zip wrapper.
+- Re-run `register-baseline` for every new macOS store release before its first patch.

--- a/scripts/shorebird_mas_patch.rb
+++ b/scripts/shorebird_mas_patch.rb
@@ -1,0 +1,472 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Vendored from https://gist.github.com/lukemmtt/d52a729010f30c74d004ecd169805dca
+# Workaround for shorebirdtech/shorebird#3223 (Mac App Store binary mismatch).
+# See scripts/README-shorebird-macos.md for the BikeControl-specific setup.
+# Only the APP_NAME / APP_BUNDLE_ID defaults below were changed from upstream so
+# future upstream updates stay easy to diff.
+
+require "base64"
+require "digest"
+require "fileutils"
+require "json"
+require "net/http"
+require "open3"
+require "openssl"
+require "rubygems"
+require "shellwords"
+require "time"
+require "yaml"
+
+APP_NAME = ENV.fetch("APP_NAME", "BikeControl")
+APP_BUNDLE_ID = ENV.fetch("APP_BUNDLE_ID", "de.jonasbark.swiftPlay")
+ASC_APP_ID = ENV.fetch("ASC_APP_ID", "1234567890")
+ASC_KEY_ID = ENV.fetch("ASC_KEY_ID", "ABCDEFGHIJ")
+ASC_ISSUER_ID = ENV.fetch("ASC_ISSUER_ID", "00000000-0000-0000-0000-000000000000")
+ASC_API_KEY_PATH = File.expand_path(ENV.fetch("ASC_API_KEY_PATH", "~/.private_keys/AuthKey_#{ASC_KEY_ID}.p8"))
+MACOS_APP_PATH = File.expand_path(ENV.fetch("MACOS_APP_PATH", "/Applications/#{APP_NAME}.app"))
+MAS_ARTIFACT_ARCH = ENV["SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH"] || ENV["MAS_ARTIFACT_ARCH"] || "app_mas_contents"
+SHOREBIRD_BIN = ENV["SHOREBIRD_BIN"].to_s.empty? ? "shorebird" : ENV["SHOREBIRD_BIN"]
+SHOREBIRD_YAML_PATH = File.expand_path(ENV.fetch("SHOREBIRD_YAML_PATH", "shorebird.yaml"))
+PATCHER_PATH = File.expand_path(ENV.fetch("SHOREBIRD_MACOS_PATCHER_PATH", "~/.shorebird/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart"))
+PATCH_ARGS = ENV.fetch("SHOREBIRD_PATCH_ARGS", "--allow-asset-diffs --min-link-percentage=90")
+INSTALL_TIMEOUT_SECONDS = Integer(ENV.fetch("MAS_INSTALL_TIMEOUT_SECONDS", "300"))
+
+def say(message)
+  warn(message)
+end
+
+def die(message)
+  abort("error: #{message}")
+end
+
+def run(*args, env: {}, allow_failure: false)
+  args = args.flatten
+  say("$ #{args.shelljoin}")
+  ok = system(env, *args)
+  die("command failed: #{args.shelljoin}") if !ok && !allow_failure
+  ok
+end
+
+def capture(*args, env: {}, allow_failure: false)
+  args = args.flatten
+  stdout, stderr, status = Open3.capture3(env, *args)
+  die("command failed: #{args.shelljoin}\n#{stdout}#{stderr}") if !status.success? && !allow_failure
+  stdout
+end
+
+def shell_capture(command, allow_failure: false)
+  stdout, stderr, status = Open3.capture3("sh", "-lc", command)
+  die("command failed: #{command}\n#{stdout}#{stderr}") if !status.success? && !allow_failure
+  stdout
+end
+
+def b64url(bytes)
+  Base64.urlsafe_encode64(bytes).delete("=")
+end
+
+def asn1_ecdsa_to_raw(signature_der)
+  sequence = OpenSSL::ASN1.decode(signature_der)
+  r = sequence.value[0].value.to_s(2).rjust(32, "\0")[-32, 32]
+  s = sequence.value[1].value.to_s(2).rjust(32, "\0")[-32, 32]
+  r + s
+end
+
+def asc_private_key
+  key_content = ENV["ASC_API_KEY_CONTENT"] || File.read(ASC_API_KEY_PATH)
+  OpenSSL::PKey.read(key_content)
+rescue Errno::ENOENT
+  die("App Store Connect key not found at #{ASC_API_KEY_PATH}. Set ASC_API_KEY_PATH or ASC_API_KEY_CONTENT.")
+end
+
+def asc_jwt
+  now = Time.now.to_i
+  header = { alg: "ES256", kid: ASC_KEY_ID, typ: "JWT" }
+  payload = { iss: ASC_ISSUER_ID, iat: now, exp: now + 20 * 60, aud: "appstoreconnect-v1" }
+  signing_input = "#{b64url(header.to_json)}.#{b64url(payload.to_json)}"
+  digest = OpenSSL::Digest::SHA256.digest(signing_input)
+  signature_der = asc_private_key.dsa_sign_asn1(digest)
+  "#{signing_input}.#{b64url(asn1_ecdsa_to_raw(signature_der))}"
+end
+
+def asc_get(path, query = {})
+  uri = URI("https://api.appstoreconnect.apple.com#{path}")
+  uri.query = URI.encode_www_form(query) unless query.empty?
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    req = Net::HTTP::Get.new(uri)
+    req["Authorization"] = "Bearer #{asc_jwt}"
+    http.request(req)
+  end
+  die("App Store Connect GET #{path} failed (HTTP #{response.code}): #{response.body}") unless response.code.to_i < 300
+  JSON.parse(response.body)
+end
+
+def build_map(body)
+  (body["included"] || [])
+    .select { |record| record["type"] == "builds" }
+    .each_with_object({}) { |build, map| map[build["id"]] = build }
+end
+
+def latest_ready_for_sale_release_version
+  body = asc_get(
+    "/v1/apps/#{ASC_APP_ID}/appStoreVersions",
+    "filter[platform]" => "MAC_OS",
+    "include" => "build",
+    "fields[builds]" => "version",
+    "limit" => "50"
+  )
+  builds = build_map(body)
+  ready_versions = (body["data"] || []).select { |version| version.dig("attributes", "appStoreState") == "READY_FOR_SALE" }
+  die("No READY_FOR_SALE Mac App Store version found for ASC app #{ASC_APP_ID}.") if ready_versions.empty?
+
+  best = ready_versions.max_by do |version_record|
+    version = version_record.dig("attributes", "versionString").to_s
+    build_id = version_record.dig("relationships", "build", "data", "id")
+    build_number = builds.dig(build_id, "attributes", "version").to_i
+    [Gem::Version.new(version), build_number]
+  end
+
+  build_id = best.dig("relationships", "build", "data", "id")
+  build_number = builds.dig(build_id, "attributes", "version")
+  die("READY_FOR_SALE version #{best.dig("attributes", "versionString")} has no attached build.") if build_number.to_s.empty?
+
+  release_version = "#{best.dig("attributes", "versionString")}+#{build_number}"
+  say("Mac App Store READY_FOR_SALE release: #{release_version}")
+  release_version
+end
+
+def release_version
+  value = ENV["RELEASE_VERSION"].to_s.strip
+  return value unless value.empty?
+
+  latest_ready_for_sale_release_version
+end
+
+def parse_release_version!(value)
+  version, build_number = value.to_s.strip.split("+", 2)
+  die("Release version must look like x.y.z+build, got #{value.inspect}") if version.to_s.empty? || build_number.to_s.empty?
+  [version, build_number]
+end
+
+def shorebird_app_id
+  YAML.load_file(SHOREBIRD_YAML_PATH).fetch("app_id")
+rescue Errno::ENOENT
+  die("Could not find shorebird.yaml at #{SHOREBIRD_YAML_PATH}. Run from your Flutter app root or set SHOREBIRD_YAML_PATH.")
+end
+
+def shorebird_google_oauth_client
+  # These are Shorebird CLI's native-app OAuth client values, not user credentials.
+  # Read them from the installed CLI instead of copying the literals into this script.
+  auth_path = File.expand_path("~/.shorebird/packages/shorebird_cli/lib/src/auth/auth.dart")
+  source = File.exist?(auth_path) ? File.read(auth_path) : ""
+  google_block = source[/case AuthProvider\.google:.*?case AuthProvider\.microsoft:/m]
+  values = google_block.to_s.scan(/['"]{1,3}([^'"\n]+(?:apps\.googleusercontent\.com|GOCSPX-[^'"\n]+))['"]{1,3}/).flatten
+  client_id = values.find { |value| value.end_with?(".apps.googleusercontent.com") }
+  client_secret = values.find { |value| value.start_with?("GOCSPX-") }
+  die("Could not find Shorebird CLI Google OAuth client values in #{auth_path}. Run `shorebird login`, or set a fresh local credentials.json token.") if client_id.to_s.empty? || client_secret.to_s.empty?
+  [client_id, client_secret]
+end
+
+def shorebird_api_token
+  if ENV["SHOREBIRD_TOKEN"].to_s.strip != ""
+    ci_token = JSON.parse(Base64.decode64(ENV.fetch("SHOREBIRD_TOKEN")))
+    die("Unsupported Shorebird auth provider: #{ci_token["auth_provider"]}") unless ci_token["auth_provider"] == "google"
+    client_id, client_secret = shorebird_google_oauth_client
+
+    uri = URI("https://oauth2.googleapis.com/token")
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      req = Net::HTTP::Post.new(uri)
+      req.set_form_data(
+        "client_id" => client_id,
+        "client_secret" => client_secret,
+        "refresh_token" => ci_token.fetch("refresh_token"),
+        "grant_type" => "refresh_token"
+      )
+      http.request(req)
+    end
+    die("Google OAuth refresh failed (HTTP #{response.code}): #{response.body}") unless response.code == "200"
+    return JSON.parse(response.body).fetch("id_token")
+  end
+
+  credentials_path = File.expand_path("~/Library/Application Support/shorebird/credentials.json")
+  return JSON.parse(File.read(credentials_path)).fetch("idToken") if File.exist?(credentials_path)
+
+  die("No Shorebird auth available. Set SHOREBIRD_TOKEN or run `shorebird login`.")
+end
+
+def shorebird_api(method_class, path, query: nil, body: nil)
+  uri = URI("https://api.shorebird.dev#{path}")
+  uri.query = URI.encode_www_form(query) if query && !query.empty?
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    req = method_class.new(uri)
+    req["Authorization"] = "Bearer #{shorebird_api_token}"
+    req["x-version"] = "0.9.0+1"
+    if body
+      req["Content-Type"] = "application/json"
+      req.body = body.to_json
+    end
+    http.request(req)
+  end
+  parsed = JSON.parse(response.body.empty? ? "{}" : response.body)
+  die("Shorebird API unauthorized. Check SHOREBIRD_TOKEN or run `shorebird login`.") if parsed["code"] == "user_unauthorized"
+  die("Shorebird API #{method_class} #{path} failed (HTTP #{response.code}): #{response.body}") unless response.code.to_i < 300
+  parsed
+end
+
+def shorebird_release_for_version(value)
+  body = shorebird_api(Net::HTTP::Get, "/api/v1/apps/#{shorebird_app_id}/releases")
+  release = (body["releases"] || []).find { |record| record["version"] == value }
+  die("No Shorebird release found for #{value}. Run `shorebird release macos` for this version before registering the MAS baseline.") unless release
+  release
+end
+
+def shorebird_release_artifacts(release_id:, arch:, platform:)
+  body = shorebird_api(
+    Net::HTTP::Get,
+    "/api/v1/apps/#{shorebird_app_id}/releases/#{release_id}/artifacts",
+    query: { "arch" => arch, "platform" => platform }
+  )
+  body["artifacts"] || []
+end
+
+def ensure_shorebird_release_artifact!(value)
+  release = shorebird_release_for_version(value)
+  artifacts = shorebird_release_artifacts(release_id: release.fetch("id"), arch: MAS_ARTIFACT_ARCH, platform: "macos")
+  die("Shorebird release #{value} has no macos/#{MAS_ARTIFACT_ARCH} artifact. Run `ruby #{$PROGRAM_NAME} register-baseline` first.") if artifacts.empty?
+  say("Shorebird release #{value} has #{artifacts.size} macos/#{MAS_ARTIFACT_ARCH} artifact(s).")
+  artifacts.first
+end
+
+def upload_shorebird_release_artifact!(release_id:, artifact_path:, arch:, platform:)
+  hash = Digest::SHA256.file(artifact_path).hexdigest
+  size = File.size(artifact_path)
+  create_command = [
+    "curl", "--http1.1", "--retry", "3", "--retry-all-errors", "-sS", "-f", "-X", "POST",
+    "-H", "Authorization: Bearer #{shorebird_api_token}",
+    "-H", "x-version: 0.9.0+1",
+    "-F", "arch=#{arch}",
+    "-F", "platform=#{platform}",
+    "-F", "hash=#{hash}",
+    "-F", "filename=#{File.basename(artifact_path)}",
+    "-F", "can_sideload=true",
+    "-F", "size=#{size}",
+    "https://api.shorebird.dev/api/v1/apps/#{shorebird_app_id}/releases/#{release_id}/artifacts"
+  ]
+
+  stdout, stderr, status = Open3.capture3(*create_command)
+  die("Shorebird artifact registration failed (exit #{status.exitstatus}): #{stdout}#{stderr}") unless status.success?
+  response = JSON.parse(stdout)
+  upload_url = response["url"]
+  die("Shorebird artifact registration response did not include upload url: #{response}") if upload_url.to_s.empty?
+
+  upload_stdout, upload_stderr, upload_status = Open3.capture3(
+    "curl", "--http1.1", "--retry", "3", "--retry-all-errors", "-sS", "-f", "-X", "POST", "-F", "file=@#{artifact_path}", upload_url
+  )
+  die("Shorebird artifact upload failed (exit #{upload_status.exitstatus}): #{upload_stdout}#{upload_stderr}") unless upload_status.success?
+  say("Uploaded Shorebird #{platform}/#{arch} artifact #{File.basename(artifact_path)} (sha256 #{hash})")
+  response.merge("local_hash" => hash, "local_size" => size)
+end
+
+def plist_value(plist_path, key)
+  capture("/usr/libexec/PlistBuddy", "-c", "Print :#{key}", plist_path).strip
+end
+
+def macos_app_bundle_info(app_path)
+  die("App not installed at #{app_path}. Install it from the Mac App Store or let the script update it.") unless File.directory?(app_path)
+  info_plist = File.join(app_path, "Contents", "Info.plist")
+  executable_name = plist_value(info_plist, "CFBundleExecutable")
+  {
+    version: plist_value(info_plist, "CFBundleShortVersionString"),
+    build_number: plist_value(info_plist, "CFBundleVersion"),
+    executable_name: executable_name,
+    app_executable: File.join(app_path, "Contents", "MacOS", executable_name),
+    flutter_executable: File.join(app_path, "Contents", "Frameworks", "App.framework", "App")
+  }
+end
+
+def macos_app_signing_authorities(app_path)
+  stdout, stderr, = Open3.capture3("codesign", "-dvvv", app_path)
+  (stdout + stderr).lines.filter_map { |line| line.split("Authority=", 2).last&.strip if line.include?("Authority=") }
+end
+
+def mas_signed_app_matches?(version:, build_number:)
+  info = macos_app_bundle_info(MACOS_APP_PATH) rescue nil
+  authorities = File.directory?(MACOS_APP_PATH) ? macos_app_signing_authorities(MACOS_APP_PATH) : []
+  info &&
+    info[:version] == version &&
+    info[:build_number] == build_number &&
+    authorities.any? { |authority| authority.include?("Apple Mac OS Application Signing") }
+end
+
+def install_or_update_mas_app!(version:, build_number:)
+  return if mas_signed_app_matches?(version: version, build_number: build_number)
+
+  say("Installed app does not match #{version}+#{build_number}; installing/updating from the Mac App Store.")
+  run("osascript", "-e", "tell application id \"#{APP_BUNDLE_ID}\" to quit", allow_failure: true)
+
+  if ENV["MAS_UPDATE_COMMAND"].to_s.strip != ""
+    run("sh", "-lc", ENV.fetch("MAS_UPDATE_COMMAND"))
+  else
+    mas_bin = shell_capture("command -v mas", allow_failure: true).strip
+    die("`mas` CLI not found. Install with `brew install mas`, install the live app manually, or set MAS_UPDATE_COMMAND.") if mas_bin.empty?
+    run("sudo", mas_bin, "install", "--force", ASC_APP_ID, allow_failure: true)
+    run("sudo", mas_bin, "update", "--force", "--verbose", ASC_APP_ID, allow_failure: true)
+  end
+
+  deadline = Time.now + INSTALL_TIMEOUT_SECONDS
+  until mas_signed_app_matches?(version: version, build_number: build_number)
+    die("Timed out waiting for Mac App Store app #{version}+#{build_number} at #{MACOS_APP_PATH}. Install/update it manually and rerun.") if Time.now > deadline
+    sleep 5
+  end
+end
+
+def capture_macos_installed_app_artifact!(value)
+  version, build_number = parse_release_version!(value)
+  info = macos_app_bundle_info(MACOS_APP_PATH)
+  die("Installed app is #{info[:version]}+#{info[:build_number]}, expected #{value}.") unless info[:version] == version && info[:build_number] == build_number
+  die("Missing Flutter executable at #{info[:flutter_executable]}. The zip must contain Contents/Frameworks/App.framework/App.") unless File.exist?(info[:flutter_executable])
+  die("Missing main executable at #{info[:app_executable]}.") unless File.exist?(info[:app_executable])
+
+  run("codesign", "--verify", "--deep", "--strict", MACOS_APP_PATH)
+  authorities = macos_app_signing_authorities(MACOS_APP_PATH)
+  say("Mac app signing authorities: #{authorities.join(" > ")}")
+  die("Installed app is not Mac App Store signed. Expected Apple Mac OS Application Signing authority.") unless authorities.any? { |authority| authority.include?("Apple Mac OS Application Signing") }
+
+  artifact_dir = File.join(ENV["RUNNER_TEMP"] || "/tmp", "shorebird-macos-mas-artifacts")
+  FileUtils.mkdir_p(artifact_dir)
+  zip_path = File.join(artifact_dir, "#{APP_NAME}-#{value.tr("+", "-")}-mas.app.zip")
+  File.delete(zip_path) if File.exist?(zip_path)
+
+  run("ditto", "--norsrc", "-c", "-k", MACOS_APP_PATH, zip_path, env: { "COPYFILE_DISABLE" => "1" })
+
+  {
+    path: zip_path,
+    sha256: Digest::SHA256.file(zip_path).hexdigest,
+    size: File.size(zip_path),
+    app_executable_sha256: Digest::SHA256.file(info[:app_executable]).hexdigest,
+    flutter_executable_sha256: Digest::SHA256.file(info[:flutter_executable]).hexdigest
+  }
+end
+
+def invalidate_shorebird_cache!
+  stamp_path = File.expand_path("~/.shorebird/bin/cache/shorebird.stamp")
+  File.delete(stamp_path) if File.exist?(stamp_path)
+end
+
+def with_shorebird_macos_arch_override
+  die("Could not find local Shorebird macos_patcher.dart at #{PATCHER_PATH}. Set SHOREBIRD_MACOS_PATCHER_PATH if your Shorebird install is elsewhere.") unless File.exist?(PATCHER_PATH)
+
+  original = File.read(PATCHER_PATH)
+  changed = false
+
+  unless original.include?("SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH")
+    modified = original
+      .sub("import 'dart:io';", "import 'dart:io' hide Platform;\nimport 'dart:io' as io show Platform;")
+      .sub("String get primaryReleaseArtifactArch => 'app';", "String get primaryReleaseArtifactArch =>\n      io.Platform.environment['SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH'] ?? 'app';")
+
+    die("Unable to patch local Shorebird CLI. macos_patcher.dart no longer has the expected import/getter shape.") if modified == original || !modified.include?("SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH")
+    File.write(PATCHER_PATH, modified)
+    changed = true
+    invalidate_shorebird_cache!
+    run(SHOREBIRD_BIN, "--version")
+  end
+
+  yield
+ensure
+  if defined?(changed) && changed && defined?(original)
+    File.write(PATCHER_PATH, original)
+    invalidate_shorebird_cache!
+  end
+end
+
+def register_mas_baseline!
+  value = release_version
+  version, build_number = parse_release_version!(value)
+  release = shorebird_release_for_version(value)
+
+  install_or_update_mas_app!(version: version, build_number: build_number)
+  artifact = capture_macos_installed_app_artifact!(value)
+
+  say("Captured MAS app artifact: #{artifact[:path]}")
+  say("  zip sha256: #{artifact[:sha256]}")
+  say("  App.framework/App sha256: #{artifact[:flutter_executable_sha256]}")
+  say("  main executable sha256: #{artifact[:app_executable_sha256]}")
+
+  existing = shorebird_release_artifacts(release_id: release.fetch("id"), arch: MAS_ARTIFACT_ARCH, platform: "macos")
+  if existing.any?
+    if existing.any? { |artifact_record| artifact_record["hash"] == artifact[:sha256] }
+      say("Shorebird #{value} already has matching macos/#{MAS_ARTIFACT_ARCH} artifact.")
+      return
+    end
+
+    die("Shorebird #{value} already has a macos/#{MAS_ARTIFACT_ARCH} artifact with a different hash. Re-run register-baseline and patch with MAS_ARTIFACT_ARCH=#{MAS_ARTIFACT_ARCH}_v2.")
+  end
+
+  if ENV["DRY_RUN"] == "true"
+    say("Dry run complete; MAS artifact captured and validated but not uploaded.")
+    return
+  end
+
+  upload_shorebird_release_artifact!(
+    release_id: release.fetch("id"),
+    artifact_path: artifact.fetch(:path),
+    arch: MAS_ARTIFACT_ARCH,
+    platform: "macos"
+  )
+
+  ensure_shorebird_release_artifact!(value)
+  say("Registered Mac App Store Shorebird baseline for #{value} as macos/#{MAS_ARTIFACT_ARCH}.")
+end
+
+def patch_mas_release!
+  value = release_version
+  ensure_shorebird_release_artifact!(value)
+
+  patch_args = Shellwords.split(PATCH_ARGS)
+  patch_args << "--dry-run" if ENV["DRY_RUN"] == "true" && !patch_args.include?("--dry-run")
+
+  with_shorebird_macos_arch_override do
+    run(
+      SHOREBIRD_BIN,
+      "patch",
+      "--platforms=macos",
+      "--release-version", value,
+      *patch_args,
+      env: { "SHOREBIRD_MACOS_RELEASE_ARTIFACT_ARCH" => MAS_ARTIFACT_ARCH }
+    )
+  end
+end
+
+def baseline_status!
+  value = release_version
+  ensure_shorebird_release_artifact!(value)
+end
+
+def usage!
+  script = $PROGRAM_NAME
+  warn <<~USAGE
+    Usage:
+      ruby #{script} register-baseline
+      ruby #{script} status
+      ruby #{script} patch
+
+    Common environment:
+      RELEASE_VERSION=x.y.z+build
+      MAS_ARTIFACT_ARCH=app_mas_contents_v2
+      DRY_RUN=true
+      SHOREBIRD_PATCH_ARGS="--allow-asset-diffs --min-link-percentage=90 --track staging"
+  USAGE
+  exit 64
+end
+
+case ARGV.shift
+when "register-baseline"
+  register_mas_baseline!
+when "status"
+  baseline_status!
+when "patch"
+  patch_mas_release!
+else
+  usage!
+end


### PR DESCRIPTION
## Summary
Enables Shorebird OTA patches for the macOS App Store build, working around [shorebirdtech/shorebird#3223](https://github.com/shorebirdtech/shorebird/issues/3223) (still open). Apple re-processes the submitted `.pkg`, so patches built from Shorebird's original `macos/app` artifact download but fail to load at runtime — the long-standing reason macOS patching was disabled (our #143).

The fix registers the **store-delivered** `.app` as a second release artifact (`macos/app_mas_contents`) and points `shorebird patch` at it. Script vendored from [lukemmtt's gist](https://gist.github.com/lukemmtt/d52a729010f30c74d004ecd169805dca).

## Changes
- **`scripts/shorebird_mas_patch.rb`** — vendored workaround with BikeControl defaults (`APP_NAME`, `APP_BUNDLE_ID`); only those two constants diverge from upstream. Commands: `register-baseline`, `status`, `patch`.
- **`scripts/README-shorebird-macos.md`** — repo-adapted setup (env → existing App Store Connect secrets + new optional `ASC_MACOS_APP_ID`), local-vs-CI split, CLI-shim caveat.
- **`.github/workflows/build.yml`** — enable `shorebird release macos` (removed `&& false`), include macOS in Setup Shorebird, disable the plain `flutter build macos` it replaces. Store binary now carries the updater and a release record exists to patch against.
- **`.github/workflows/patch.yml`** — replace the disabled stock `shorebird-patch` macOS step with a script-driven patch (ASC key prep + `ruby scripts/shorebird_mas_patch.rb patch`), guarded by `build_mac` (off by default). Update stale #143 comments.

## ⚠️ Before this works
1. **`register-baseline` is local-only** — it needs a Mac signed into the App Store with the live app downloaded (`mas`), so it can't run in CI. Per macOS release: ship via `build.yml` → wait for `READY_FOR_SALE` → run `register-baseline` on a Mac → then patch. The CI patch step fails fast with a clear message if no baseline exists.
2. **This changes what ships to macOS App Store users** — from a plain Flutter build to a Shorebird-instrumented one. Unavoidable (plain builds aren't patchable); the next macOS submission is the real test.

## Open decisions
- Added a **CI patch path** (off by default) alongside the local flow; references a new secret `ASC_MACOS_APP_ID` (only used for version auto-detect). Can drop it for local-only.
- **No beta-track duplicate** for macOS (other platforms re-patch beta when track=stable), to keep the CLI-shim path minimal.

## Test plan
- [x] `ruby -c scripts/shorebird_mas_patch.rb` → Syntax OK
- [x] both workflows parse as valid YAML
- [ ] `shorebird release macos` succeeds in CI and uploads to the Mac App Store
- [ ] local `register-baseline` against a live `READY_FOR_SALE` build
- [ ] `patch` produces a macOS patch that loads on a store-installed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)